### PR TITLE
f-branch-1

### DIFF
--- a/app/Filament/Resources/QuestionResource.php
+++ b/app/Filament/Resources/QuestionResource.php
@@ -10,6 +10,8 @@ use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 
 class QuestionResource extends Resource
@@ -50,6 +52,9 @@ class QuestionResource extends Resource
                 Tables\Columns\TextColumn::make('percentage')
                     ->sortable()
                     ->searchable(),
+                Tables\Columns\TextColumn::make('profession.profession')
+                    ->sortable()
+                    ->searchable(),
                 Tables\Columns\TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()
@@ -60,7 +65,8 @@ class QuestionResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                SelectFilter::make('profession')
+                    ->relationship('profession', 'profession')
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),

--- a/app/Filament/Resources/QuestionResource/Pages/ListQuestions.php
+++ b/app/Filament/Resources/QuestionResource/Pages/ListQuestions.php
@@ -17,6 +17,16 @@ class ListQuestions extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            Actions\Action::make('recalculatePercentages')
+                ->label('Recalculate Percentages')
+                ->action(function (): void {
+                    // Вызываем метод пересчета процентов для всех вопросов
+                    Question::recalculatePercentages();
+                })
+                ->color('success')
+                ->requiresConfirmation()
+                ->modalHeading('Confirm Recalculation'),
+
             Actions\Action::make('import')
                 ->form([
                     Select::make('profession_id')

--- a/app/Filament/Resources/QuestionResource/Pages/ListQuestions.php
+++ b/app/Filament/Resources/QuestionResource/Pages/ListQuestions.php
@@ -48,7 +48,7 @@ class ListQuestions extends ListRecords
                     }
 
                     // Регулярное выражение для извлечения таймкода и текста вопроса
-                    $pattern = '/^(?P<start_time>\d{2}:\d{2}:\d{2},\d{3}) - (?P<question_text>.+)$/';
+                    $pattern = '/^(?P<start_time>\d{1,2}:\d{2}:\d{2},\d{3}) - (?P<question_text>.+)$/';
 
                     // Обрабатываем каждую запись
                     collect($json)->each(function ($record) use ($pattern, $data) {
@@ -66,8 +66,10 @@ class ListQuestions extends ListRecords
                                 $startTime = $matches['start_time'];
                                 $questionText = $matches['question_text'];
 
-                                // Ищем существующий таймкод по тексту вопроса (без таймкода)
-                                $timestamp = Timestamp::where('question_text', $questionText)
+                                // Ищем существующий таймкод по тексту вопроса и времени начала
+                                $timestamp = Timestamp::query()
+                                    ->where('question_text', $questionText)
+                                    ->where('start_time', $startTime)
                                     ->first();
 
                                 // Если таймкод существует, обновляем его поля
@@ -78,9 +80,10 @@ class ListQuestions extends ListRecords
                                 }
                             }
                         }
-
-                        Question::recalculatePercentages();
                     });
+
+                    // Вызываем метод пересчета процентов для всех вопросов
+                    Question::recalculatePercentages();
                 })
                 ->color('info')
                 ->label('Import Json'),

--- a/app/Filament/Resources/VideoResource.php
+++ b/app/Filament/Resources/VideoResource.php
@@ -92,6 +92,7 @@ class VideoResource extends Resource
                 //
             ])
             ->actions([
+                Tables\Actions\DeleteAction::make(),
                 Tables\Actions\EditAction::make(),
             ])
             ->bulkActions([

--- a/app/Filament/Resources/VideoResource/Pages/ListVideos.php
+++ b/app/Filament/Resources/VideoResource/Pages/ListVideos.php
@@ -3,7 +3,10 @@
 namespace App\Filament\Resources\VideoResource\Pages;
 
 use App\Filament\Resources\VideoResource;
+use App\Models\Video;
 use Filament\Actions;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
 use Filament\Resources\Pages\ListRecords;
 
 class ListVideos extends ListRecords
@@ -13,6 +16,42 @@ class ListVideos extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            Actions\Action::make('import_questions')
+                ->form([
+                    Select::make('profession_id')
+                        ->relationship('profession', 'profession')
+                        ->required(),
+                    Select::make('user_id')
+                        ->relationship('user', 'name')
+                        ->required(),
+                    Textarea::make('json')
+                        ->rows(10)
+                        ->cols(20)
+                        ->required()
+                        ->placeholder('Введите JSON здесь...'),
+                ])
+                ->action(function (array $data): void {
+                    // Декодируем JSON
+                    $json = json_decode($data['json'], true);
+
+                    // Проверяем, правильно ли декодировался JSON
+                    if (json_last_error() !== JSON_ERROR_NONE) {
+                        throw new \Exception('Некорректный JSON: ' . json_last_error_msg());
+                    }
+
+
+                    collect($json)->each(function ($record) use ($data) {
+                        Video::create([
+                            'name' => $record['title'],
+                            'url' => $record['url'],
+                            'user_id' => $data['user_id'],
+                            'profession_id' => $data['profession_id'],
+                            'status' => 'processed',
+                        ]);
+                    });
+                })
+                ->color('info')
+                ->label('Import Video Json'),
             Actions\CreateAction::make(),
         ];
     }

--- a/app/Helpers/PaginationHelper.php
+++ b/app/Helpers/PaginationHelper.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Helpers;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PaginationHelper
+{
+    public static function paginate(Builder|HasMany $query, int $perPage, int $currentPage = 1): array
+    {
+        $offset = ($currentPage - 1) * $perPage;
+        $total = $query->count();
+        $items = $query->offset($offset)->limit($perPage)->get();
+        $lastPage = (int) ceil($total / $perPage);
+
+        return [
+            'items' => $items,
+            'total' => $total,
+            'lastPage' => $lastPage,
+        ];
+    }
+}

--- a/app/Livewire/ProfessionQuestions.php
+++ b/app/Livewire/ProfessionQuestions.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use App\DTO\ProfessionQuestionsDTO;
 use App\DTO\QuestionDTO;
+use App\Helpers\PaginationHelper;
 use App\Models\Profession;
 use App\Models\Question;
 use Livewire\Attributes\Layout;
@@ -19,30 +20,52 @@ class ProfessionQuestions extends Component
     public array $questions = [];
     public bool $filtered = false;
 
+    public bool $list = false;
+    public int $currentPage = 1;
+    public int $lastPage;
+
+    public function setTypeView( bool $list ): void
+    {
+        $this->list = $list;
+    }
     public function setLevel(string|null $levelId): void
     {
         $this->filtered = $levelId !== null;
-
         $this->questions = $this->getQuestions($levelId);
+
+        $this->dispatch('scrollToTop');
     }
 
     public function setTag(string|null $tagId): void
     {
         $this->filtered = $tagId !== null;
         $this->questions = $this->getQuestions(null, $tagId);
+
+        $this->dispatch('scrollToTop');
     }
 
     public function filterClear(): void
     {
         $this->filtered = false;
         $this->questions = $this->getQuestions();
+
+        $this->dispatch('scrollToTop');
+    }
+
+    public function newPage(int $page): void
+    {
+        $this->currentPage = $page;
+        $this->questions = $this->getQuestions();
+
+        $this->dispatch('scrollToTop');
     }
 
     private function getQuestions(?string $levelId = null, ?string $tagId = null): array
     {
         $profession = Profession::query()->findOrFail($this->profession['id']);
 
-        return QuestionDTO::collect(
+        $perPage = 50;
+        $questions = PaginationHelper::paginate(
             $profession->questions()
                 ->when($levelId, fn($query) => $query->where('level_id', $levelId))
                 ->when($tagId, function ($query) use ($tagId) {
@@ -50,10 +73,14 @@ class ProfessionQuestions extends Component
                         $tagQuery->where('tag_id', $tagId);
                     });
                 })
-                ->orderByDesc('percentage')
-                ->limit(20)
-                ->get()
-        )->toArray();
+                ->orderByDesc('percentage'),
+            $perPage,
+            $this->currentPage
+        );
+
+        $this->lastPage = $questions['lastPage'];
+
+        return QuestionDTO::collect($questions['items'])->toArray();
     }
 
     public function mount(string $professionId): void

--- a/app/Observers/QuestionObserver.php
+++ b/app/Observers/QuestionObserver.php
@@ -27,7 +27,7 @@ class QuestionObserver
      */
     public function deleted(Question $question): void
     {
-        Question::recalculatePercentages();
+        //Question::recalculatePercentages();
     }
 
     /**

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,24 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+*::-webkit-scrollbar {
+    @apply w-1.5; /* Толщина скроллбара */
+}
+
+*::-webkit-scrollbar-track {
+    @apply bg-white; /* Цвет трека скроллбара */
+}
+
+*::-webkit-scrollbar-thumb {
+    @apply bg-gray-200 rounded-lg; /* Цвет ползунка скроллбара */
+}
+
+/* Темная тема для скроллбара */
+.dark *::-webkit-scrollbar-track {
+    @apply bg-neutral-800;  /* Цвет трека в темной теме */
+}
+
+.dark *::-webkit-scrollbar-thumb {
+    @apply bg-neutral-700 rounded-lg; /* Цвет ползунка в темной теме */
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,3 +6,11 @@ import Clipboard from '@ryangjchandler/alpine-clipboard'
 Alpine.plugin(Clipboard)
 
 Livewire.start()
+
+
+Livewire.on('scrollToTop', () => {
+    window.scrollTo({
+        top: 0,
+        behavior: 'smooth'
+    });
+});

--- a/resources/views/components/profession-questions/dropdown-filter.blade.php
+++ b/resources/views/components/profession-questions/dropdown-filter.blade.php
@@ -1,4 +1,4 @@
-<div class="flex flex-col sm:flex-row sm:items-center gap-3 justify-between">
+<div class="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-6 justify-between">
     <div class="relative w-full">
         <input
             type="text"
@@ -9,7 +9,7 @@
             <x-mdi-magnify class="shrink-0 size-4 text-gray-500 dark:text-neutral-500"/>
         </div>
     </div>
-    <div class="flex justify-end gap-3 items-center">
+    <div class="flex justify-end gap-3 sm:gap-6 items-center">
         @if($filtered)
             <button
                 x-on:click.prevent="$wire.filterClear()"
@@ -19,7 +19,7 @@
                 Сбросить
             </button>
         @endif
-        <div class="flex gap-3">
+        <div class="flex gap-3 sm:gap-6">
             <div class="hs-dropdown [--strategy:absolute] [--flip:false] [--placement:bottom-right] hs-dropdown-example relative inline-flex">
                 <button
                         id="hs-dropdown-example"
@@ -39,7 +39,7 @@
                         aria-labelledby="hs-dropdown-transform-style"
                 >
                     <div class="hs-dropdown-open:ease-in hs-dropdown-open:opacity-100 hs-dropdown-open:scale-100 transition ease-out opacity-0 scale-95 duration-200 mt-2 origin-top-left min-w-60 bg-white shadow-md rounded-lg dark:bg-neutral-800 dark:border dark:border-neutral-700 dark:divide-neutral-700" data-hs-transition>
-                        <div class="p-1 space-y-0.5">
+                        <div class="p-1 max-h-96 overflow-y-auto space-y-0.5">
                             @if(count($tags) == 0)
                                 <p class="py-2 px-3 text-sm text-gray-600 dark:text-neutral-400">Темы не найдены</p>
                             @endif

--- a/resources/views/components/profession-questions/question-item-list.blade.php
+++ b/resources/views/components/profession-questions/question-item-list.blade.php
@@ -1,0 +1,22 @@
+<a
+    wire:key="{{ $questionId }}"
+    class="group grid bg-white border shadow-sm rounded-xl hover:shadow-md focus:outline-none focus:shadow-md transition dark:bg-neutral-900 dark:border-neutral-800"
+    href="{{ route('answers', $questionId) }}"
+    wire:navigate
+>
+    <div class="flex justify-between p-4 md:p-5 gap-4 ">
+        <div>
+            <h3 class="font-semibold text-gray-800 dark:text-neutral-200">
+                {{ $question }}
+            </h3>
+            <p class="text-sm text-gray-500 dark:text-neutral-500">
+                Подается в {{ $percentage }}% случаях
+            </p>
+
+        </div>
+        <div class="flex items-center text-blue-600 decoration-2 group-hover:text-blue-500 group-hover:dark:text-blue-600 font-medium dark:text-blue-500">
+            <span class="hidden lg:flex" >Перейти к ответу</span>
+            <x-mdi-arrow-right class="size-5"/>
+        </div>
+    </div>
+</a>

--- a/resources/views/components/profession-questions/title-with-icon.blade.php
+++ b/resources/views/components/profession-questions/title-with-icon.blade.php
@@ -1,5 +1,24 @@
-<div class="mb-10">
-    <x-dynamic-component :component="$icon" :class="$iconColor . ' size-14'" />
-    <h2 class="text-2xl font-bold md:text-4xl md:leading-tight dark:text-white">{{ $title }}</h2>
-    <p class="mt-1 text-gray-600 dark:text-neutral-400">{{ $description }}</p>
+<div class="flex items-center justify-between mb-10">
+    <div>
+        <x-dynamic-component :component="$icon" :class="$iconColor . ' size-14'" />
+        <h2 class="text-2xl font-bold md:text-4xl md:leading-tight dark:text-white">{{ $title }}</h2>
+        <p class="mt-1 text-gray-600 dark:text-neutral-400">{{ $description }}</p>
+    </div>
+
+    <div class="flex justify-end rounded-lg mt-3 sm:mt-6 shadow-sm">
+        <button
+            wire:click="setTypeView(true)"
+            type="button"
+            class="p-3 inline-flex items-center gap-x-2 -ms-px first:rounded-s-lg first:ms-0 last:rounded-e-lg text-sm font-medium focus:z-10 border border-gray-200 bg-white text-gray-800 shadow-sm hover:bg-gray-50 focus:outline-none focus:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-900 dark:border-neutral-700 dark:text-white dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+        >
+            <x-mdi-view-headline class="size-6"/>
+        </button>
+        <button
+            wire:click="setTypeView(false)"
+            type="button"
+            class="p-3 inline-flex items-center gap-x-2 -ms-px first:rounded-s-lg first:ms-0 last:rounded-e-lg text-sm font-medium focus:z-10 border border-gray-200 bg-white text-gray-800 shadow-sm hover:bg-gray-50 focus:outline-none focus:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-900 dark:border-neutral-700 dark:text-white dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+        >
+            <x-mdi-view-grid-outline class="size-6"/>
+        </button>
+    </div>
 </div>

--- a/resources/views/components/ui/pagination.blade.php
+++ b/resources/views/components/ui/pagination.blade.php
@@ -1,0 +1,35 @@
+@props(['lastPage', 'currentPage','clickPage'])
+
+<nav class="flex items-center gap-x-1">
+    <button
+        wire:click="{{$clickPage.'('.($currentPage - 1).')'}}"
+        class="min-h-[32px] min-w-8 py-2 px-2 inline-flex justify-center items-center gap-x-2 text-sm rounded-lg text-gray-800 hover:bg-gray-100 focus:outline-none focus:bg-gray-100
+               @if($currentPage === 1) pointer-events-none opacity-50 @endif
+               dark:text-white dark:hover:bg-white/10 dark:focus:bg-white/10"
+        @if($currentPage === 1) disabled @endif
+    >
+        <x-mdi-chevron-left />
+        <span aria-hidden="true" class="sr-only">Previous</span>
+    </button>
+
+    <div class="flex items-center gap-x-1">
+        <span class="min-h-[32px] min-w-8 flex justify-center items-center border border-gray-200 text-gray-800 py-1 px-3 text-sm rounded-lg focus:outline-none focus:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none dark:border-neutral-700 dark:text-white dark:focus:bg-neutral-800">
+            {{ $currentPage }}
+        </span>
+        <span class="min-h-[32px] flex justify-center items-center text-gray-500 py-1.5 px-1.5 text-sm dark:text-neutral-500">из</span>
+        <span class="min-h-[32px] flex justify-center items-center text-gray-500 py-1.5 px-1.5 text-sm dark:text-neutral-500">
+            {{ $lastPage }}
+        </span>
+    </div>
+
+    <button
+        wire:click="{{$clickPage.'('.($currentPage + 1).')'}}"
+        class="min-h-[32px] min-w-8 py-2 px-2 inline-flex justify-center items-center gap-x-2 text-sm rounded-lg text-gray-800 hover:bg-gray-100 focus:outline-none focus:bg-gray-100
+               @if($currentPage === $lastPage) pointer-events-none opacity-50 @endif
+               dark:text-white dark:hover:bg-white/10 dark:focus:bg-white/10"
+        @if($currentPage === $lastPage) disabled @endif
+    >
+        <span aria-hidden="true" class="sr-only">Next</span>
+        <x-mdi-chevron-right />
+    </button>
+</nav>

--- a/resources/views/livewire/profession-questions.blade.php
+++ b/resources/views/livewire/profession-questions.blade.php
@@ -17,20 +17,41 @@
     @if(count($this->questions) == 0)
         <x-profession-questions.empty-list />
     @else
-        <div class="max-w-[85rem] py-10 lg:py-14 mx-auto">
-            <div class="grid md:grid-cols-2 gap-3 sm:gap-6">
-                @foreach($this->questions as $question)
-                    <x-profession-questions.question-item
-                        :questionId="$question['id']"
-                        :question="$question['question']"
-                        :percentage="$question['percentage']"
-                        :tags="$question['tags']"
-                        :level="$question['level']"
-                        :level-icon="$question['level_icon']"
-                    />
-                @endforeach
-            </div>
+        <div class="max-w-[85rem] py-3 sm:py-6 mx-auto">
+            @if($this->list)
+                <div class="grid gap-3 sm:gap-6">
+                    @foreach($this->questions as $question)
+                        <x-profession-questions.question-item-list
+                            :questionId="$question['id']"
+                            :question="$question['question']"
+                            :percentage="$question['percentage']"
+                            :tags="$question['tags']"
+                            :level="$question['level']"
+                            :level-icon="$question['level_icon']"
+                        />
+                    @endforeach
+                </div>
+            @else
+                <div class="grid md:grid-cols-2 gap-3 sm:gap-6">
+                    @foreach($this->questions as $question)
+                        <x-profession-questions.question-item
+                            :questionId="$question['id']"
+                            :question="$question['question']"
+                            :percentage="$question['percentage']"
+                            :tags="$question['tags']"
+                            :level="$question['level']"
+                            :level-icon="$question['level_icon']"
+                        />
+                    @endforeach
+                </div>
+            @endif
         </div>
     @endif
+
+    <x-ui.pagination
+        :lastPage="$this->lastPage"
+        :currentPage="$this->currentPage"
+        clickPage="newPage"
+    />
 
 </div>


### PR DESCRIPTION
Here is the pull request description:

```
feat: Implement pagination, filtering, and view toggle for profession questions

This pull request introduces several improvements to the `ProfessionQuestions` Livewire component:

1. Implement pagination for the list of questions, with a configurable page size (50 items per page by default).
2. Add a "Recalculate Percentages" action in the Filament resource for the `Question` model, which triggers a recalculation of the percentage for all questions.
3. Enhance the `getQuestions` method in the `ProfessionQuestions` component to support pagination and filtering by level and tag.
4. Add new methods to the `ProfessionQuestions` component to handle changing the view type (list or grid), navigating to a specific page, and clearing the filters.
5. Create a new `PaginationHelper` class to encapsulate the logic for paginating a query.

These changes improve the user experience by providing a more manageable way to browse and filter the list of questions for a specific profession.

Additionally, this PR includes the following improvements:

- Add smooth scrolling and custom scrollbar styles
- Increase the gap between dropdown filters on smaller screens
- Add a view toggle to switch between grid and list view of questions
- Ensure the view toggle is responsive and styled appropriately
```